### PR TITLE
remove stg flag

### DIFF
--- a/packages/edp-extension/package.json
+++ b/packages/edp-extension/package.json
@@ -7,7 +7,7 @@
     "build": "pnpm citron && vite build --mode production && pnpm zip-dist",
     "start": "pnpm citron && vite --port 3001",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "pnpm preview-extension --stg && pnpm start",
+    "preview": "pnpm preview-extension && pnpm start",
     "zip-dist": "cd dist && bestzip ../extension.zip * && cd ..",
     "remove-preview": "pnpm remove-extension-preview",
     "postinstall": "pnpm citron"


### PR DESCRIPTION
removing `--stg` flag from review script so the users use production environment by default. 